### PR TITLE
Drop system dependency on RHEL

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -39,6 +39,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
+      --skip-keys benchmark
     devel_branch: main
     last_version: 0.0.4
     name: upstream


### PR DESCRIPTION
The Google Benchmark system package is not available for RHEL 7, which is the only RPM distribution we're targeting.